### PR TITLE
fix: update README heading with repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aftercoding
+# textresearch
 
 This repository contains a prototype survey analysis tool that processes Japanese free-text responses.
 It leverages spaCy with SudachiPy and OpenAI's models to summarize sentiment, topics and actionable insights from Excel files.


### PR DESCRIPTION
## Summary
- replace placeholder heading with repository name `textresearch`

## Testing
- `python scripts/compile_all.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68900ec9f8188333839ae0bba086ba8f